### PR TITLE
fix: Allow filtering null in arrayFirst & arrayFirstIndex functions

### DIFF
--- a/src/Functions/array/arrayFirstLast.cpp
+++ b/src/Functions/array/arrayFirstLast.cpp
@@ -28,7 +28,7 @@ enum class ArrayFirstLastElementNotExistsStrategy : uint8_t
 template <ArrayFirstLastStrategy strategy, ArrayFirstLastElementNotExistsStrategy element_not_exists_strategy>
 struct ArrayFirstLastImpl
 {
-    static bool needBoolean() { return false; }
+    static bool needBoolean() { return true; }
     static bool needExpression() { return true; }
     static bool needOneArray() { return false; }
 

--- a/src/Functions/array/arrayFirstLastIndex.cpp
+++ b/src/Functions/array/arrayFirstLastIndex.cpp
@@ -21,7 +21,7 @@ enum class ArrayFirstLastIndexStrategy : uint8_t
 template <ArrayFirstLastIndexStrategy strategy>
 struct ArrayFirstLastIndexImpl
 {
-    static bool needBoolean() { return false; }
+    static bool needBoolean() { return true; }
     static bool needExpression() { return true; }
     static bool needOneArray() { return false; }
 

--- a/tests/queries/0_stateless/03530_higher_order_functions_null_filter.reference
+++ b/tests/queries/0_stateless/03530_higher_order_functions_null_filter.reference
@@ -1,0 +1,5 @@
+arrayFirst
+2
+['arrayFilter']
+1
+0

--- a/tests/queries/0_stateless/03530_higher_order_functions_null_filter.sql
+++ b/tests/queries/0_stateless/03530_higher_order_functions_null_filter.sql
@@ -1,0 +1,5 @@
+SELECT arrayFirst(x -> x != '', [NULL, 'arrayFirst']);
+SELECT arrayFirstIndex(x -> x != '', [NULL, 'arrayFirstIndex']);
+SELECT arrayFilter(x -> x != '', [NULL, 'arrayFilter']);
+SELECT arrayExists(x -> x != '', [NULL, 'arrayExists']);
+SELECT arrayAll(x -> x != '', [NULL, 'arrayAll']);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Allow for filtering NULL values in arrayFirst, arrayFirstIndex, arrayLast & arrayLastIndex. Fixes #81113

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->